### PR TITLE
feat: make workflows organization-agnostic

### DIFF
--- a/.github/workflows/update-formulas.yml
+++ b/.github/workflows/update-formulas.yml
@@ -12,8 +12,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ vars.DOBBOBOT_APP_ID }}
-          private-key: ${{ secrets.DOBBOBOT_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.AUTOMATIONS_APP_ID }}
+          private-key: ${{ secrets.AUTOMATIONS_APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/update-formulas.yml
+++ b/.github/workflows/update-formulas.yml
@@ -27,12 +27,18 @@ jobs:
           DARWIN_AMD64_SHA256="${{ github.event.client_payload.darwin_amd64_sha256 }}"
           LINUX_ARM64_SHA256="${{ github.event.client_payload.linux_arm64_sha256 }}"
           LINUX_AMD64_SHA256="${{ github.event.client_payload.linux_amd64_sha256 }}"
+          ORGANIZATION="${{ github.repository_owner }}"
           
           echo "Updating editorlint formula to version: $VERSION"
+          echo "Organization: $ORGANIZATION"
           echo "Darwin ARM64 SHA256: $DARWIN_ARM64_SHA256"
           echo "Darwin AMD64 SHA256: $DARWIN_AMD64_SHA256"
           echo "Linux ARM64 SHA256: $LINUX_ARM64_SHA256"
           echo "Linux AMD64 SHA256: $LINUX_AMD64_SHA256"
+          
+          # Update homepage and URLs to use current organization
+          sed -i "s|homepage \"https://github.com/[^/]*/editorlint\"|homepage \"https://github.com/${ORGANIZATION}/editorlint\"|" Formula/editorlint.rb
+          sed -i "s|https://github.com/[^/]*/editorlint/|https://github.com/${ORGANIZATION}/editorlint/|g" Formula/editorlint.rb
           
           # Update version
           sed -i "s|version \".*\"|version \"${VERSION}\"|" Formula/editorlint.rb

--- a/Formula/editorlint.rb
+++ b/Formula/editorlint.rb
@@ -1,25 +1,25 @@
 class Editorlint < Formula
   desc "A comprehensive tool to validate and fix files according to .editorconfig specifications"
-  homepage "https://github.com/cdobbyn/editorlint"
+  homepage "https://github.com/dobbo-ca/editorlint"
   license "MIT"
   version "1.3.9"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/cdobbyn/editorlint/releases/download/1.3.9/editorlint_v1.3.9_darwin_arm64.tar.gz"
+      url "https://github.com/dobbo-ca/editorlint/releases/download/1.3.9/editorlint_v1.3.9_darwin_arm64.tar.gz"
       sha256 "9cece0ffe7cad27ff7fcb1c337fe9443ae5b5bf872f179491e00ecf629d6db75"
     else
-      url "https://github.com/cdobbyn/editorlint/releases/download/1.3.9/editorlint_v1.3.9_darwin_amd64.tar.gz"
+      url "https://github.com/dobbo-ca/editorlint/releases/download/1.3.9/editorlint_v1.3.9_darwin_amd64.tar.gz"
       sha256 "36d79bf043239a159aac280e050511da91a44f1b5a91e67b56bb8f4b7dc8dfd2"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/cdobbyn/editorlint/releases/download/1.3.9/editorlint_v1.3.9_linux_arm64.tar.gz"
+      url "https://github.com/dobbo-ca/editorlint/releases/download/1.3.9/editorlint_v1.3.9_linux_arm64.tar.gz"
       sha256 "905f998166df2ead06e0363f178883651169a5bf7960b476ebd0fa1ce60a23e1"
     else
-      url "https://github.com/cdobbyn/editorlint/releases/download/1.3.9/editorlint_v1.3.9_linux_amd64.tar.gz"
+      url "https://github.com/dobbo-ca/editorlint/releases/download/1.3.9/editorlint_v1.3.9_linux_amd64.tar.gz"
       sha256 "586a4966758dba043d62729c2e3da24f1adea24994c2772a88694e95416da2f4"
     end
   end

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains Homebrew formulas for cdobbyns tools.
 ## Installation
 
 ```bash
-brew tap cdobbyn/taps
+brew tap dobbo-ca/taps
 brew install editorlint
 ```
 
@@ -22,7 +22,7 @@ After tapping this repository, you can install any of the available tools:
 brew install editorlint
 
 # Or install directly without tapping first
-brew install cdobbyn/taps/editorlint
+brew install dobbo-ca/taps/editorlint
 ```
 
 ## Updating


### PR DESCRIPTION
Makes workflows automatically adapt to the current organization name instead of hardcoding 'dobbo-ca'.

- Use ${{ github.repository_owner }} for dynamic organization detection
- Update Homebrew formula to use current organization URLs
- Replace hardcoded organization names in homepage and download URLs
- Enable repository to work seamlessly if moved to different organization

This allows the repository to be moved to any GitHub organization without requiring manual updates to workflow files.