### PR TITLE
docs: update installation instructions for organization change

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.{diff,md}]
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Homebrew Taps
 
-This repository contains Homebrew formulas for cdobbyns tools.
+This repository contains Homebrew formulas for editorlint tools.
 
 ## Installation
 
 ```bash
-brew tap dobbo-ca/taps
+brew tap editorlint/taps
 brew install editorlint
 ```
 
@@ -22,7 +22,7 @@ After tapping this repository, you can install any of the available tools:
 brew install editorlint
 
 # Or install directly without tapping first
-brew install dobbo-ca/taps/editorlint
+brew install editorlint/taps/editorlint
 ```
 
 ## Updating


### PR DESCRIPTION
Updates the README to reflect the organization change from dobbo-ca to editorlint.

## Changes
- Update organization from `dobbo-ca` to `editorlint` 
- Fix Homebrew tap reference to use correct convention (`editorlint/taps`)
- Update description to reflect editorlint tools

## Testing
- Verified Homebrew tap naming convention (homebrew- prefix automatically handled)
- Updated both tap and direct install commands